### PR TITLE
fix: Omit config fields we cannot serialise

### DIFF
--- a/launcher/launcher.go
+++ b/launcher/launcher.go
@@ -311,8 +311,8 @@ type Config struct {
 	SpanProcessors                  []trace.SpanProcessor
 	Sampler                         trace.Sampler
 	Resource                        *resource.Resource
-	Logger                          Logger
-	ShutdownFunctions               []func(c *Config) error
+	Logger                          Logger                  `json:"-"`
+	ShutdownFunctions               []func(c *Config) error `json:"-"`
 	errorHandler                    otel.ErrorHandler
 }
 

--- a/launcher/launcher_test.go
+++ b/launcher/launcher_test.go
@@ -2,6 +2,7 @@ package launcher
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"net"
 	"net/http"
@@ -301,6 +302,24 @@ func TestDefaultConfig(t *testing.T) {
 		Sampler:                         trace.AlwaysSample(),
 	}
 	assert.Equal(t, expected, config)
+}
+
+func TestDefaultConfigMarshal(t *testing.T) {
+	logger := &testLogger{}
+	handler := &testErrorHandler{}
+	config := newConfig(
+		WithLogger(logger),
+		WithErrorHandler(handler),
+		WithShutdown(func(c *Config) error {
+			return nil
+		}),
+	)
+
+	j, err := json.Marshal(config)
+
+	assert.NoError(t, err)
+
+	assert.NotEmpty(t, j)
 }
 
 func TestEnvironmentVariables(t *testing.T) {


### PR DESCRIPTION
## Which problem is this PR solving?

When we set the debug log level we attempt to marshal the config as JSON over [here](https://github.com/honeycombio/opentelemetry-go-contrib/blob/launcher/launcher/config.go#L563)

This fails if you have provided a `Logger` or `ShutdownFunctions` so we should omit from the JSON

## Short description of the changes

Add JSON tags to the config struct to omit the fields we cannot serialise

## How to verify that this has the expected result

run the tests