### PR TITLE
fix: `launcher.WithSampler` doesn't get passed all the way through

### DIFF
--- a/launcher/launcher.go
+++ b/launcher/launcher.go
@@ -568,6 +568,7 @@ func setupTracing(c *Config) (func() error, error) {
 		Resource:       c.Resource,
 		Propagators:    c.Propagators,
 		SpanProcessors: c.SpanProcessors,
+		Sampler:        c.Sampler,
 	})
 }
 


### PR DESCRIPTION
## Which problem is this PR solving?

Currently passing `launcher.WithSampler(myCustomSampler)` into  `launcher.ConfigureOpenTelemetry` & friends doesn't do anything.

## Short description of the changes

This PR ensures that when constructing the `pipelines.PipelineConfig` it passes in the provided `launcher.Config.Sampler` instead of not.

## How to verify that this has the expected result

Added a test using the `dummyGRPCServer` & an extended `testSampler` that shows that the sampler isn't being used. Then updated the `pipelines.NewTracePipeline(pipelines.PipelineConfig{...})` to include the passed in `Sampler` and watched the test start passing.
