### PR TITLE
maint: add dependabot to project

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,19 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://help.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+
+version: 2
+updates:
+  - package-ecosystem: "gomod" # See documentation for possible values
+    directory: "/" # Location of package manifests
+    schedule:
+      interval: "monthly"
+    labels:
+      - "type: dependencies"
+    reviewers:
+      - "honeycombio/telemetry-team"
+    commit-message:
+      prefix: "maint"
+      include: "scope"
+      


### PR DESCRIPTION
## Which problem is this PR solving?

- no dependabot

## Short description of the changes

- Create .github/dependabot.yml

## How to verify that this has the expected result

dependabot PRs start coming through when newer versions of dependencies are available