### PR TITLE
ci: add go 1.20 to ci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,9 +3,9 @@ version: 2.1
 matrix_goversions: &matrix_goversions
   matrix:
     parameters:
-      goversion: ["18", "19"]
+      goversion: ["18", "19", "20"]
 
-default_goversion: &default_goversion "18"
+default_goversion: &default_goversion "20"
 
 orbs:
   bats: circleci/bats@1.0.0


### PR DESCRIPTION
<!--
Thank you for contributing to the project! 💜
Please see our [OSS process document](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md#) to get an idea of how we operate.
-->

## Which problem is this PR solving?

Go 1.20 was released in February!

## Short description of the changes

Add 1.20 to test matrix and use as default version.

## How to verify that this has the expected result

Tests still pass
