### PR TITLE
feat: Allow vendors to set default exporter endpoint

### DIFF
--- a/launcher/launcher.go
+++ b/launcher/launcher.go
@@ -28,6 +28,9 @@ var (
 	// ValidateConfig is a function that a vendor can implement to provide additional validation after
 	// a configuration is built.
 	ValidateConfig func(*Config) error
+	// DefaultExporterEndpoint provides a way for vendors to update the default exporter endpoint address.
+	// Defaults to 'localhost'.
+	DefaultExporterEndpoint string = "localhost"
 )
 
 // These are strings because they get appended to the host.
@@ -291,7 +294,7 @@ func (l *defaultHandler) Handle(err error) {
 // vary depending on the protocol chosen. If not overridden by explicit configuration, it will
 // be overridden with an appropriate default upon initialization.
 type Config struct {
-	ExporterEndpoint                string   `env:"OTEL_EXPORTER_OTLP_ENDPOINT,default=localhost"`
+	ExporterEndpoint                string   `env:"OTEL_EXPORTER_OTLP_ENDPOINT"`
 	ExporterEndpointInsecure        bool     `env:"OTEL_EXPORTER_OTLP_INSECURE,default=false"`
 	TracesExporterEndpoint          string   `env:"OTEL_EXPORTER_OTLP_TRACES_ENDPOINT"`
 	TracesExporterEndpointInsecure  bool     `env:"OTEL_EXPORTER_OTLP_TRACES_INSECURE"`
@@ -333,6 +336,10 @@ func newConfig(opts ...Option) *Config {
 	envError := envconfig.Process(context.Background(), c)
 	if envError != nil {
 		c.Logger.Fatalf("environment error: %v", envError)
+	}
+	// if exporter endpoint is not set using an env var, use the configured default
+	if c.ExporterEndpoint == "" {
+		c.ExporterEndpoint = DefaultExporterEndpoint
 	}
 
 	// If a vendor has specific options to add, add them to opts

--- a/launcher/launcher_test.go
+++ b/launcher/launcher_test.go
@@ -870,6 +870,30 @@ func TestGenericAndSignalHeadersAreCombined(t *testing.T) {
 	assert.Nil(t, err)
 }
 
+func TestCanSetDefaultExporterEndpoint(t *testing.T) {
+	DefaultExporterEndpoint = "http://custom.endpoint"
+	config := newConfig()
+	assert.Equal(t, "http://custom.endpoint", config.ExporterEndpoint)
+}
+
+func TestCustomDefaultExporterEndpointDoesNotReplaceEnvVar(t *testing.T) {
+	setEnvironment()
+	DefaultExporterEndpoint = "http://custom.endpoint"
+	config := newConfig()
+	assert.Equal(t, "http://generic-url", config.ExporterEndpoint)
+	unsetEnvironment()
+}
+
+func TestCustomDefaultExporterEndpointDoesNotReplaceOption(t *testing.T) {
+	setEnvironment()
+	DefaultExporterEndpoint = "http://http://custom.endpoint"
+	config := newConfig(
+		WithExporterEndpoint("http://other.endpoint"),
+	)
+	assert.Equal(t, "http://other.endpoint", config.ExporterEndpoint)
+	unsetEnvironment()
+}
+
 type testSampler struct {
 	decsision  trace.SamplingDecision
 	attributes []attribute.KeyValue


### PR DESCRIPTION
## Which problem is this PR solving?
Allows vendors to set the default exporter endpoint instead of having to rely on using a vendor option as using a vendor option always squashes the `OTEL_EXPORTER_OTLP_ENDPOINT` env var.

Setting the default before creating the options struct allows it to fallback as expected: eg option > env var > default

## Short description of the changes
Add new DefaultExporterEndpoint variable for vendors to set during their package init.

## How to verify that this has the expected result
Added unit tests to verify behaviour, both in setting it and checking the fallback behaviour.